### PR TITLE
Fix: cold LED never fully off when warm_light_color_temp_kelvin > 2000K

### DIFF
--- a/custom_components/color_temperature_light_mixer/config_flow_handler/schemas/config.py
+++ b/custom_components/color_temperature_light_mixer/config_flow_handler/schemas/config.py
@@ -67,6 +67,8 @@ def get_user_schema(defaults: Mapping[str, Any] | None = None) -> vol.Schema:
             ): selector.ColorTempSelector(
                 selector.ColorTempSelectorConfig(
                     unit=selector.ColorTempSelectorUnit.KELVIN,
+                    min=2000,
+                    max=6500,
                 ),
             ),
             vol.Required(
@@ -118,6 +120,8 @@ def get_reconfigure_schema(defaults: Mapping[str, str]) -> vol.Schema:
             ): selector.ColorTempSelector(
                 selector.ColorTempSelectorConfig(
                     unit=selector.ColorTempSelectorUnit.KELVIN,
+                    min=2000,
+                    max=6500,
                 ),
             ),
             vol.Required(

--- a/custom_components/color_temperature_light_mixer/light/color_temperature_mixer.py
+++ b/custom_components/color_temperature_light_mixer/light/color_temperature_mixer.py
@@ -156,8 +156,8 @@ class ColorTemperatureMixerLight(LightGroup, ColorTemperatureMixerEntity, Restor
         )
 
         brightness_calculator = BrightnessCalculator(
-            self.min_color_temp_kelvin,
-            self.max_color_temp_kelvin,
+            self.__warm_light.color_temp_kelvin,
+            self.__cold_light.color_temp_kelvin,
             target_temp_kelvin,
             target_brightness,
             priority,
@@ -203,7 +203,8 @@ class ColorTemperatureMixerLight(LightGroup, ColorTemperatureMixerEntity, Restor
         self._attr_supported_color_modes = {ColorMode.COLOR_TEMP}
         # Ensure COLOR_TEMP is always the current mode, since it is the main feature of the group
         self._attr_color_mode = ColorMode.COLOR_TEMP
-
+        self._attr_min_color_temp_kelvin = self.__warm_light.color_temp_kelvin
+        self._attr_max_color_temp_kelvin = self.__cold_light.color_temp_kelvin
         states = [state for entity_id in self._entity_ids if (state := self.hass.states.get(entity_id)) is not None]
         on_states = [state for state in states if state.state == STATE_ON]
 


### PR DESCRIPTION
## Description

This PR fixes two related bugs that cause the cold LED channel to never fully turn off when `warm_light_color_temp_kelvin` is set to a value higher than 2000K (e.g. 2400K or 2700K strips), making fully warm light impossible regardless of configuration.

### Bug 1 — `light/color_temperature_mixer.py`: `BrightnessCalculator` uses wrong anchor values

In `async_turn_on`, `BrightnessCalculator` was called with `self.min_color_temp_kelvin` and `self.max_color_temp_kelvin`. These properties get overwritten to HA's hardcoded defaults (2000K / 6500K) by the `LightGroup` parent class on every state update, silently ignoring the user-configured `warm_light_color_temp_kelvin` and `cold_light_color_temp_kelvin` values.

For example, with a warm strip rated at 2400K, sending `color_temp_kelvin: 2400` to the virtual light results in the cold channel receiving ~9% brightness instead of 0%, because the formula computes:
```
cold_ratio = (2400 - 2000) / (6500 - 2000) = 8.9%
```
when it should compute:
```
cold_ratio = (2400 - 2400) / (6500 - 2400) = 0%
```

Fix: pass `self.__warm_light.color_temp_kelvin` and `self.__cold_light.color_temp_kelvin` directly to `BrightnessCalculator`, and restore the correct min/max after each state update in `async_update_group_state`.

### Bug 2 — `config_flow_handler/schemas/config.py`: UI slider blocked at 2700K minimum

`ColorTempSelectorConfig` for the warm light had no explicit `min`/`max`, so HA defaulted to a 2700K floor. This prevents users with warmer LED strips (e.g. 2400K) from configuring them via the UI at all, forcing them to use YAML.

Fix: add `min=2000, max=6500` to the warm light `ColorTempSelectorConfig` in both `get_user_schema` and `get_reconfigure_schema`.

## Related Issue

Fixes #(issue)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have read the `CONTRIBUTING.md` document
- [ ] My code follows the code style of this project (run `script/lint`)
- [ ] I have updated the documentation accordingly
- [ ] I have updated the translations if needed

## Testing

Tested manually on Home Assistant 2026.7.0b1 with a Shelly RGBW2 controlling two separate LED channels (warm: 2400K, cold: 6500K) via the `color_temperature_light_mixer` integration.

**Before fix:** sending `color_temp_kelvin: 2400` to the virtual light resulted in the cold channel at brightness ~13 (instead of 0). Confirmed via debug logging:
```
Decomposed brightnesses cold: 13, warm: 41
```

**After fix:** sending `color_temp_kelvin: 2400` results in the cold channel at brightness 0 and the warm channel at full brightness. Cold LEDs fully off as expected.

Also verified that the UI warm light temperature slider now allows values below 2700K down to 2000K.

## Screenshots (if applicable)

N/A